### PR TITLE
Change astropy version requirements to be different for python2 and python3 (#120)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ from io import open
 with open('README.md', encoding="utf-8") as f:
     long_description = f.read()
 
-
-
 setup(name='Stile',
       version='0.1',
       description='Stile: Systematics Tests in Lensing pipeline',

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,15 @@ from io import open
 with open('README.md', encoding="utf-8") as f:
     long_description = f.read()
 
+
+
 setup(name='Stile',
       version='0.1',
       description='Stile: Systematics Tests in Lensing pipeline',
       author='The Stile team',
-      install_requires=['numpy', 'treecorr', 'matplotlib', 'astropy<3'],
+      install_requires=['numpy', 'treecorr', 'matplotlib', 
+        'astropy<3;python_version<"3.0"',
+        'astropy;python_version>="3.0"'],
       author_email='melanie.simet@gmail.com',
       url='https://github.com/msimet/Stile',
       packages=['stile', 'stile.hsc'],


### PR DESCRIPTION
Since the DM stack now requires astropy>3.0 for python3, switch our setup.py file to install different versions of astropy depending on which version of python we're using.  